### PR TITLE
feat: copy link to register if `open_cmd` length is 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ require("browsher").setup({
     --- Allow line numbers with uncommitted changes.
     allow_line_numbers_with_uncommitted_changes = false,
     --- Command to open URLs (e.g., 'firefox').
+    --- If this is a single character, it will be interpreted as a vim register
+    --- instead. For example, to copy the url to your OS clipboard instead of
+    --- opening it inside an application, set `open_cmd` to `+` for unix systems,
+    --- or `*` if you're on Windows.
     open_cmd = nil,
     --- Custom providers for building URLs.
     ---

--- a/lua/browsher/init.lua
+++ b/lua/browsher/init.lua
@@ -17,6 +17,7 @@ local function get_open_command()
             return config.options.open_cmd
         end
     end
+
     if vim.fn.has("unix") == 1 then
         return { "xdg-open" }
     elseif vim.fn.has("macunix") == 1 then
@@ -35,6 +36,10 @@ local function open_url(url)
     local open_cmd = get_open_command()
     if not open_cmd then
         utils.notify("Unsupported OS", vim.log.levels.ERROR)
+        return
+    elseif string.len(open_cmd[1]) == 1 then
+        vim.fn.setreg(open_cmd[1], url)
+        utils.notify("URL copied to '" .. open_cmd[1] .. "' register", vim.log.levels.INFO)
         return
     end
 


### PR DESCRIPTION
Instead of guessing a command to use to open a browser with, if `open_cmd` is `nil`, copy the URL to the  `+` register.

The `+` register is considered by many terminals to be the OS native clipboard, so this makes it easy to e.g. share links to highlighted parts of the code with colleagues.