### PR TITLE
Fix default open command for OSX

### DIFF
--- a/lua/browsher/init.lua
+++ b/lua/browsher/init.lua
@@ -18,10 +18,10 @@ local function get_open_command()
         end
     end
 
-    if vim.fn.has("unix") == 1 then
-        return { "xdg-open" }
-    elseif vim.fn.has("macunix") == 1 then
+    if vim.fn.has("macunix") == 1 then
         return { "open" }
+    elseif vim.fn.has("unix") == 1 then
+        return { "xdg-open" }
     elseif vim.fn.has("win32") == 1 then
         return { "explorer.exe" }
     else

--- a/lua/browsher/init.lua
+++ b/lua/browsher/init.lua
@@ -37,7 +37,14 @@ end
 local function open_url(url)
     local open_cmd = get_open_command()
     if not open_cmd then
-        utils.notify("Unsupported OS", vim.log.levels.ERROR)
+        local error_msg = [[
+Could not determine which command used by your operating system to
+open a browser from the command-line.
+
+You must explicitly set the "open_cmd" option in your configuration
+for Browsher to function.
+        ]]
+        utils.notify(error_msg, vim.log.levels.ERROR)
         return
     elseif string.len(open_cmd[1]) == 1 then
         vim.fn.setreg(open_cmd[1], url)

--- a/lua/browsher/init.lua
+++ b/lua/browsher/init.lua
@@ -18,11 +18,13 @@ local function get_open_command()
         end
     end
 
-    if vim.fn.has("macunix") == 1 then
-        return { "open" }
-    elseif vim.fn.has("unix") == 1 then
+    local os_name = vim.loop.os_uname().sysname
+
+    if os_name == "Linux" then
         return { "xdg-open" }
-    elseif vim.fn.has("win32") == 1 then
+    elseif os_name == "Darwin" then
+        return { "open" }
+    elseif os_name == "Windows_NT" then
         return { "explorer.exe" }
     else
         return nil


### PR DESCRIPTION
Hey there!

I ran into an issue with the default open command using OSX and I unfortunately wasn't able to get around this by changing my `open_cmd`. I found out that this was because `vim.fn.has("macunix")` and `vim.fn.has("unix")` both return 1 on OSX.

I structured this in separate commits so you can pick and choose what changes you want, and I'm happy to rebase however you need:

1. First commit - Swap the order of `vim.fn.has` calls to fix the issue.
2. Second commit - Replace `vim.fn.has` with `vim.uv.os_uname().sysname`
3. Third commit - Expand the error message so that its clear what follow-up is required without needing to look at the source

Hope this helps the next person! 🙏🏻 Lemme know if you have any questions or need any changes!