### PR TITLE
Add Sourcehut VCS provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 - **Open files in the browser**: Quickly open the current file in your remote Git repository's web interface.
 - **Line and Range Support**: Supports opening specific lines or ranges, including multiline selections from visual mode.
-- **Customizable providers**: Support for GitHub, GitLab, and the ability to specify custom git web interfaces.
+- **Customizable providers**: Support for GitHub, GitLab, Sourcehut, and the ability to specify custom git web interfaces.
 - **Custom open commands**: Specify custom commands to open URLs (e.g., use a specific browser).
 
 # 📦 Installation
@@ -80,6 +80,11 @@ require("browsher").setup({
             url_template = "%s/-/blob/%s/%s",
             single_line_format = "#L%d",
             multi_line_format = "#L%d-%d",
+        },
+        ["sr.ht"] = {
+            url_template = "%s/tree/%s/item/%s",
+            single_line_format = "#L%d",
+            multi_line_format = "#L%d",
         },
     },
 })

--- a/lua/browsher/config.lua
+++ b/lua/browsher/config.lua
@@ -46,6 +46,11 @@ M.options = {
             single_line_format = "#L%d",
             multi_line_format = "#L%d-%d",
         },
+        ["sr.ht"] = {
+            url_template = "%s/tree/%s/item/%s",
+            single_line_format = "#L%d",
+            multi_line_format = "#L%d",
+        },
     },
 }
 


### PR DESCRIPTION
This adds Sourcehut support! No pressure to accept it, but there are a bunch of Fennel plugins that exist over there and I figured some folks might get utility out of this.

Sourcehut doesn't support multi-line strings in the URL though, so I have it set to the same as the single-line-format. I think `nil` will fail otherwise, and in this case, `string.format` should ignore the additional parameter.