### PR TITLE
expose predefined providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,18 @@ require("browsher").setup({
 })
 ```
 
+## Self-hosted providers
+
+Reuse a built-in provider definition for a self-hosted instance:
+
+```lua
+require("browsher").setup({
+    providers = {
+        ["gitlab.example.com"] = require("browsher").providers["gitlab.com"],
+    },
+})
+```
+
 ## Shorter URLs
 
 Pinning to a commit gives a link that never drifts. The full 40 character hash makes that link long.

--- a/doc/browsher.txt
+++ b/doc/browsher.txt
@@ -1,5 +1,5 @@
 *browsher.txt* Create commit pinned links to git(hub | lab) hosted files/lines directly from Neovim
-                                For NVIM v0.8.0    Last change: 2026 August 09
+                                For NVIM v0.8.0    Last change: 2026 August 11
 
 ==============================================================================
 Table of Contents                                 *browsher-table-of-contents*
@@ -8,6 +8,7 @@ Table of Contents                                 *browsher-table-of-contents*
 2. Features                                                |browsher-features|
 3. Installation                                        |browsher-installation|
 4. Configuration                                      |browsher-configuration|
+  - Self-hosted providers       |browsher-configuration-self-hosted-providers|
   - Shorter URLs                         |browsher-configuration-shorter-urls|
   - Key Mappings                         |browsher-configuration-key-mappings|
 5. Usage                                                      |browsher-usage|
@@ -120,6 +121,19 @@ DEFAULT OPTIONS
                 single_line_format = "#L%d",
                 multi_line_format = "#L%d",
             },
+        },
+    })
+<
+
+
+SELF-HOSTED PROVIDERS       *browsher-configuration-self-hosted-providers*
+
+Reuse a built-in provider definition for a self-hosted instance:
+
+>lua
+    require("browsher").setup({
+        providers = {
+            ["gitlab.example.com"] = require("browsher").providers["gitlab.com"],
         },
     })
 <

--- a/lua/browsher/config.lua
+++ b/lua/browsher/config.lua
@@ -1,5 +1,23 @@
 local M = {}
 
+M.providers = {
+    ["github.com"] = {
+        url_template = "%s/blob/%s/%s",
+        single_line_format = "#L%d",
+        multi_line_format = "#L%d-L%d",
+    },
+    ["gitlab.com"] = {
+        url_template = "%s/-/blob/%s/%s",
+        single_line_format = "#L%d",
+        multi_line_format = "#L%d-%d",
+    },
+    ["sr.ht"] = {
+        url_template = "%s/tree/%s/item/%s",
+        single_line_format = "#L%d",
+        multi_line_format = "#L%d",
+    },
+}
+
 --- Default configuration options.
 M.options = {
     --- Default remote name (e.g., 'origin').
@@ -35,23 +53,7 @@ M.options = {
     ---   },
     --- }
     --- ```
-    providers = {
-        ["github.com"] = {
-            url_template = "%s/blob/%s/%s",
-            single_line_format = "#L%d",
-            multi_line_format = "#L%d-L%d",
-        },
-        ["gitlab.com"] = {
-            url_template = "%s/-/blob/%s/%s",
-            single_line_format = "#L%d",
-            multi_line_format = "#L%d-%d",
-        },
-        ["sr.ht"] = {
-            url_template = "%s/tree/%s/item/%s",
-            single_line_format = "#L%d",
-            multi_line_format = "#L%d",
-        },
-    },
+    providers = M.providers,
 }
 
 --- Setup user configuration.

--- a/lua/browsher/config.lua
+++ b/lua/browsher/config.lua
@@ -53,7 +53,7 @@ M.options = {
     ---   },
     --- }
     --- ```
-    providers = M.providers,
+    providers = vim.deepcopy(M.providers),
 }
 
 --- Setup user configuration.

--- a/lua/browsher/init.lua
+++ b/lua/browsher/init.lua
@@ -4,7 +4,9 @@ local url_builder = require("browsher.url")
 local utils = require("browsher.utils")
 
 --- Main module for browsher.nvim.
-local M = {}
+local M = {
+    providers = config.providers,
+}
 
 --- Get the command to open URLs based on the OS or user configuration.
 ---


### PR DESCRIPTION
Better to configure like this:
```lua
require("browsher").setup({
	providers = {
		["salsa"] = require("browsher").providers["gitlab.com"],
	},
})
```

rather than like this:
```lua
require("browsher").setup({
	providers = {
		["salsa"] = {
			url_template = "%s/-/blob/%s/%s",
			single_line_format = "#L%d",
			multi_line_format = "#L%d-%d",
		},
	},
})
```